### PR TITLE
Add env example and ignore file

### DIFF
--- a/too-rich-to-care-frontend/.env
+++ b/too-rich-to-care-frontend/.env
@@ -1,2 +1,0 @@
-VITE_API_URL=https://backend.2richtocare.com
-

--- a/too-rich-to-care-frontend/.env.example
+++ b/too-rich-to-care-frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=

--- a/too-rich-to-care-frontend/.gitignore
+++ b/too-rich-to-care-frontend/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# Environment variables
+.env
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/too-rich-to-care-frontend/README.md
+++ b/too-rich-to-care-frontend/README.md
@@ -10,4 +10,7 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
-// touch
+
+## Environment setup
+
+Copy `.env.example` to `.env` and set the `VITE_API_URL` variable to point to your backend API.


### PR DESCRIPTION
## Summary
- ignore `.env` in frontend
- add `.env.example` with `VITE_API_URL`
- document copying `.env.example` to `.env`

## Testing
- `npm test` (fails: no tests specified)
- `npm run lint` (fails to find dependencies)

------
https://chatgpt.com/codex/tasks/task_e_684b03bd8c088328834aae7ee4e024c9