### PR TITLE
Add video serving endpoint

### DIFF
--- a/too-rich-to-care-backend/src/index.js
+++ b/too-rich-to-care-backend/src/index.js
@@ -4,6 +4,7 @@ import dotenv from 'dotenv';
 import choicesRoutes from './routes/choices.js';
 import paymentsRouter from './routes/payments.js'; // ✅ Stripe
 import cartRoutes from './routes/cart.js';
+import videosRoutes from './routes/videos.js';
 
 
 dotenv.config();
@@ -24,6 +25,7 @@ app.use(express.json());
 // Rutas sin conflicto
 app.use('/choices', choicesRoutes);
 app.use('/api/cart', cartRoutes);
+app.use('/api/videos', videosRoutes);
 
 
 // Aquí dividimos el router de pagos en dos rutas:

--- a/too-rich-to-care-backend/src/routes/videos.js
+++ b/too-rich-to-care-backend/src/routes/videos.js
@@ -1,0 +1,32 @@
+import express from 'express';
+import fs from 'fs';
+import path from 'path';
+
+const router = express.Router();
+const videosDir = path.resolve('too-rich-to-care-backend/videos');
+
+router.get('/:cartId', (req, res) => {
+  const { cartId } = req.params;
+  const videoPath = path.join(videosDir, `${cartId}.mp4`);
+
+  fs.access(videoPath, fs.constants.F_OK, (err) => {
+    if (err) {
+      return res.status(404).json({ error: 'Video not found' });
+    }
+    res.sendFile(videoPath);
+  });
+});
+
+router.head('/:cartId', (req, res) => {
+  const { cartId } = req.params;
+  const videoPath = path.join(videosDir, `${cartId}.mp4`);
+
+  fs.access(videoPath, fs.constants.F_OK, (err) => {
+    if (err) {
+      return res.status(404).end();
+    }
+    res.status(200).end();
+  });
+});
+
+export default router;

--- a/too-rich-to-care-frontend/src/pages/PaymentSuccess.tsx
+++ b/too-rich-to-care-frontend/src/pages/PaymentSuccess.tsx
@@ -5,13 +5,25 @@ export default function PaymentSuccess() {
   const location = useLocation();
   const navigate = useNavigate();
   const [downloadUrl, setDownloadUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
     const cartId = params.get('cartId');
     if (cartId) {
-      // Placeholder for backend polling. Assume the backend provides a download endpoint
-      setDownloadUrl(`${import.meta.env.VITE_API_URL}/api/videos/${cartId}`);
+      const url = `${import.meta.env.VITE_API_URL}/api/videos/${cartId}`;
+      fetch(url, { method: 'HEAD' })
+        .then((res) => {
+          if (res.ok) {
+            setDownloadUrl(url);
+          } else {
+            setError('El video aún no está disponible.');
+          }
+        })
+        .catch((err) => {
+          console.error('❌ Error verificando el video:', err);
+          setError('No se pudo obtener el video.');
+        });
     }
   }, [location.search]);
 
@@ -28,6 +40,8 @@ export default function PaymentSuccess() {
         >
           Descargar video
         </a>
+      ) : error ? (
+        <p className="mb-6 text-gray-300">{error}</p>
       ) : (
         <p className="mb-6 text-gray-300">Generando enlace de descarga...</p>
       )}


### PR DESCRIPTION
## Summary
- serve cart-based videos from new `/api/videos` endpoint
- gracefully show errors in payment success page
- include a placeholder `videos` directory

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b03bb2b0883289abd116dfc33e970