### PR TITLE
Persist name in cart

### DIFF
--- a/too-rich-to-care-backend/initDb.js
+++ b/too-rich-to-care-backend/initDb.js
@@ -43,6 +43,7 @@ async function initDb() {
     CREATE TABLE carts (
       id UUID PRIMARY KEY,
       user_id TEXT,
+      name TEXT,
       created_at TIMESTAMP DEFAULT NOW()
     );
 

--- a/too-rich-to-care-backend/src/routes/cart.js
+++ b/too-rich-to-care-backend/src/routes/cart.js
@@ -4,7 +4,7 @@ import { pool } from '../db.js';
 const router = express.Router();
 
 router.post('/save-cart', async (req, res) => {
-  const { cartId, userId, items } = req.body;
+  const { cartId, userId, name, items } = req.body;
 
   if (!cartId || !userId || !Array.isArray(items)) {
     return res.status(400).json({ error: 'Datos incompletos para guardar carrito' });
@@ -17,8 +17,8 @@ router.post('/save-cart', async (req, res) => {
 
     // Guardar carrito
     await client.query(
-      'INSERT INTO carts (id, user_id) VALUES ($1, $2)',
-      [cartId, userId]
+      'INSERT INTO carts (id, user_id, name) VALUES ($1, $2, $3)',
+      [cartId, userId, name]
     );
 
     // Guardar ítems del carrito


### PR DESCRIPTION
## Summary
- store `name` when saving carts
- include `name` column in `carts` table

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` in frontend *(fails to find module '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_684b03ba24b4832889e3529ad6fd8db4