### PR TITLE
Configure CORS origins via env var

### DIFF
--- a/too-rich-to-care-backend/.env.example
+++ b/too-rich-to-care-backend/.env.example
@@ -1,6 +1,9 @@
 # Puerto donde corre el backend
 PORT=5000
 
+# Orígenes permitidos por CORS (separados por comas)
+CORS_ORIGINS=http://localhost:5173,https://too-rich-to-care-frontend.vercel.app,https://app.2richtocare.com
+
 # URL de la base de datos (PostgreSQL)
 DATABASE_URL=postgresql://user:password@host:port/database
 

--- a/too-rich-to-care-backend/src/index.js
+++ b/too-rich-to-care-backend/src/index.js
@@ -11,8 +11,18 @@ dotenv.config();
 const app = express();
 const PORT = process.env.PORT || 5000;
 
+// Allowed origins for CORS. If the environment variable is not defined,
+// fall back to the hardcoded list used previously.
+const allowedOrigins = process.env.CORS_ORIGINS
+  ? process.env.CORS_ORIGINS.split(',').map(origin => origin.trim())
+  : [
+      'http://localhost:5173',
+      'https://too-rich-to-care-frontend.vercel.app',
+      'https://app.2richtocare.com',
+    ];
+
 app.use(cors({
-  origin: ['http://localhost:5173', 'https://too-rich-to-care-frontend.vercel.app', 'https://app.2richtocare.com'],
+  origin: allowedOrigins,
 }));
 
 // Raw body parser SOLO para webhook Stripe


### PR DESCRIPTION
## Summary
- allow configuring CORS allowed origins through a `CORS_ORIGINS` environment variable
- document `CORS_ORIGINS` in `.env.example`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b03b2ade08328aff03886530076d2