### PR TITLE
Fix summary page and remove black square

### DIFF
--- a/too-rich-to-care-frontend/src/pages/SpendMoney.tsx
+++ b/too-rich-to-care-frontend/src/pages/SpendMoney.tsx
@@ -175,7 +175,7 @@ export default function SpendMoney() {
             ${moneyLeft.toLocaleString()}
           </motion.div>
 
-          <div id="fall-zone" className="relative w-full max-w-[600px] sm:w-[600px] h-[600px] sm:h-[660px] mx-auto bg-[#10131F] rounded-xl overflow-hidden -mt-20 flex items-center justify-center">
+          <div id="fall-zone" className="relative w-full max-w-[600px] sm:w-[600px] h-[600px] sm:h-[660px] mx-auto rounded-xl overflow-hidden -mt-20 flex items-center justify-center">
             <span className="text-gray-600">Buy something to burn that cash!</span>
           </div>
         </div>

--- a/too-rich-to-care-frontend/src/pages/Summary.tsx
+++ b/too-rich-to-care-frontend/src/pages/Summary.tsx
@@ -5,7 +5,7 @@ import GameLayout from '../components/GameLayout';
 
 export default function Summary() {
   const navigate = useNavigate();
-  const { billionaire, spendingActions, totalSpent, resetGame } = useGame();
+  const { billionaire, spendingActions, totalSpent, resetGame, userId } = useGame();
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -15,31 +15,30 @@ export default function Summary() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          billionaire,
-          spendingActions,
-          totalSpent,
+          billionaire: billionaire?.name,
+          userId,
         }),
       });
 
-      if (!response.ok) throw new Error('Error al enviar al backend');
+      if (!response.ok) throw new Error('Failed to send to backend');
 
       setSubmitted(true);
-      console.log('✅ Datos enviados correctamente');
+      console.log('✅ Data sent successfully');
     } catch (err) {
       console.error('❌ Error enviando al backend:', err);
-      setError('Hubo un error al guardar tus datos.');
+      setError('There was an error saving your data.');
     }
   };
 
   if (!billionaire) {
     return (
       <div className="p-4">
-        <p className="text-red-600">⚠️ No has seleccionado un billonario.</p>
+        <p className="text-red-600">⚠️ No billionaire selected.</p>
         <button
           onClick={() => navigate('/')}
           className="mt-4 px-4 py-2 bg-blue-600 text-white rounded"
         >
-          Volver al inicio
+          Back to start
         </button>
       </div>
     );
@@ -50,12 +49,12 @@ export default function Summary() {
   return (
     <GameLayout>
     <div className="p-4 relative z-10">
-      <h1 className="text-2xl font-bold mb-4">Resumen de tus acciones</h1>
-      <p className="mb-2 font-medium">Billonario: {billionaire.name}</p>
-      <p className="mb-2">Fortuna inicial: $ {billionaire.netWorth.toLocaleString()}</p>
-      <p className="mb-4">Gastado: $ {totalSpent.toLocaleString()} — Restante: $ {remaining.toLocaleString()}</p>
+      <h1 className="text-2xl font-bold mb-4">Summary of your actions</h1>
+      <p className="mb-2 font-medium">Billionaire: {billionaire.name}</p>
+      <p className="mb-2">Initial net worth: $ {billionaire.netWorth.toLocaleString()}</p>
+      <p className="mb-4">Spent: $ {totalSpent.toLocaleString()} — Remaining: $ {remaining.toLocaleString()}</p>
 
-      <h2 className="text-xl font-semibold mb-2">Has gastado en:</h2>
+      <h2 className="text-xl font-semibold mb-2">You spent on:</h2>
       <ul className="list-disc list-inside mb-6">
         {spendingActions.map((action, index) => (
           <li key={index}>
@@ -65,7 +64,7 @@ export default function Summary() {
       </ul>
 
       {error && <p className="text-red-600 mb-4">{error}</p>}
-      {submitted && <p className="text-green-600 mb-4">✅ Datos enviados correctamente.</p>}
+      {submitted && <p className="text-green-600 mb-4">✅ Data sent successfully.</p>}
 
       <div className="flex gap-4">
         {!submitted && (
@@ -73,7 +72,7 @@ export default function Summary() {
             onClick={handleSubmit}
             className="px-4 py-2 bg-green-600 text-white rounded"
           >
-            Finalizar
+            Finish
           </button>
         )}
         <button
@@ -83,7 +82,7 @@ export default function Summary() {
           }}
           className="px-4 py-2 bg-purple-600 text-white rounded"
         >
-          Reiniciar
+          Restart
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove black background from fall zone in SpendMoney
- translate Summary page to English and fix POST payload

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b2930b6348328b8491c06d20da07b