### PR TITLE
Add identity-obj-proxy to frontend dev dependencies

### DIFF
--- a/too-rich-to-care-frontend/package.json
+++ b/too-rich-to-care-frontend/package.json
@@ -28,6 +28,7 @@
     "globals": "^16.0.0",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.1",
-    "vite": "^6.3.1"
+    "vite": "^6.3.1",
+    "identity-obj-proxy": "^3.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `identity-obj-proxy` to frontend devDependencies

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684b2fd34e688328a8bbb2301fc020f9