### PR TITLE
Fix save-cart docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ The backend exposes several routes used by the frontend:
 | --- | --- |
 | `POST /choices` | Save the selected billionaire. Body expects `{ billionaire, userId }`. |
 | `GET /choices` | Retrieve all saved choices. |
-| `POST /api/cart/save-cart` | Persist the current cart before starting the payment flow. Expects `{ cartId, userId, items }`. |
+| `POST /api/cart/save-cart` | Persist the current cart before starting the payment flow. Expects `{ cartId, userId, name, items }`. |
 | `POST /api/payments/create-checkout-session` | Creates a Stripe Checkout session and returns a redirect URL. Body expects `{ userId, cartId }`. |
 | `POST /api/payments/webhook` | Stripe webhook endpoint to confirm completed payments. When a payment succeeds and `VIDEO_POD_URL` is configured, it forwards the cart and user info to that service. |
 
-The frontend points to these routes using the `VITE_API_URL` environment variable. `SelectBillionaire` posts to `/choices`, `CheckoutReview` sends the cart to `/api/cart/save-cart` and then creates the checkout session via `/api/payments/create-checkout-session`.
+The frontend points to these routes using the `VITE_API_URL` environment variable. `SelectBillionaire` posts to `/choices`, while `CheckoutReview` sends the cart and player name to `/api/cart/save-cart` and then creates the checkout session via `/api/payments/create-checkout-session`.
 
 ## Environment Variables
 


### PR DESCRIPTION
## Summary
- add `name` to cart save request payload
- clarify the description of the checkout flow

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm test --silent` in backend

------
https://chatgpt.com/codex/tasks/task_e_684b39a754a08328a69d3813a2345e00